### PR TITLE
format using brittany

### DIFF
--- a/scripts/format.ps1
+++ b/scripts/format.ps1
@@ -1,0 +1,4 @@
+$files = (Get-ChildItem -Path src -Recurse *.hs | Select-Object -Expand FullName)
+dos2unix $files
+brittany --write-mode=inplace $files
+unix2dos $files

--- a/src/Data/Expenses/Expense.hs
+++ b/src/Data/Expenses/Expense.hs
@@ -44,7 +44,6 @@ nextDate ((y, m, d), dy) (DateDir Nothing dy') =
 
 
 
-nextDate _ (DateDir (Just day') dy') =
-  -- Simply just use the new date/day
-                                       ((fromIntegral y', m', d'), dy')
+-- Simply just use the new date/day
+nextDate _ (DateDir (Just day') dy') = ((fromIntegral y', m', d'), dy')
   where (y', m', d') = DT.toGregorian day'

--- a/src/Data/Expenses/Expense.hs
+++ b/src/Data/Expenses/Expense.hs
@@ -5,22 +5,21 @@ module Data.Expenses.Expense
   )
 where
 
-import qualified Data.Time.Calendar.Compat as DT
+import qualified Data.Time.Calendar.Compat     as DT
 
-import Data.Expenses.Parse.Megaparsec.Types
-  ( DateDirective(DateDir)
-  )
+import           Data.Expenses.Parse.Megaparsec.Types
+                                                ( DateDirective(DateDir) )
 
 
 
 dayOfWeek :: DT.DayOfWeek -> Int
-dayOfWeek DT.Monday = 0
-dayOfWeek DT.Tuesday = 1
+dayOfWeek DT.Monday    = 0
+dayOfWeek DT.Tuesday   = 1
 dayOfWeek DT.Wednesday = 2
-dayOfWeek DT.Thursday = 3
-dayOfWeek DT.Friday = 4
-dayOfWeek DT.Saturday = 5
-dayOfWeek DT.Sunday = 6
+dayOfWeek DT.Thursday  = 3
+dayOfWeek DT.Friday    = 4
+dayOfWeek DT.Saturday  = 5
+dayOfWeek DT.Sunday    = 6
 
 
 
@@ -37,16 +36,15 @@ nextDate
   -> ((Int, Int, Int), DT.DayOfWeek)
 nextDate ((y, m, d), dy) (DateDir Nothing dy') =
   -- Need to calculate how many days dy' is after dy.
-  let diff = numDaysAfter dy dy'
-      day = DT.fromGregorian (fromIntegral y) m d
-      day' = DT.addDays (fromIntegral diff) day
+  let diff         = numDaysAfter dy dy'
+      day          = DT.fromGregorian (fromIntegral y) m d
+      day'         = DT.addDays (fromIntegral diff) day
       (y', m', d') = DT.toGregorian day'
-  in ((fromIntegral y', m', d'), dy')
+  in  ((fromIntegral y', m', d'), dy')
 
 
 
 nextDate _ (DateDir (Just day') dy') =
   -- Simply just use the new date/day
-  ((fromIntegral y', m', d'), dy')
-    where
-     (y', m', d') = DT.toGregorian day'
+                                       ((fromIntegral y', m', d'), dy')
+  where (y', m', d') = DT.toGregorian day'

--- a/src/Data/Expenses/Ledger.hs
+++ b/src/Data/Expenses/Ledger.hs
@@ -10,30 +10,43 @@ module Data.Expenses.Ledger
   , showLedgerTransactionFromEntry
   , showMoney
   , simpleTransactionsInJournal
-  ) where
+  )
+where
 
-import Control.Monad (mapM)
+import           Control.Monad                  ( mapM )
 
-import qualified Data.Decimal as D
+import qualified Data.Decimal                  as D
 
-import Data.List (groupBy, intercalate, lookup)
-import Data.Maybe (fromMaybe, mapMaybe)
+import           Data.List                      ( groupBy
+                                                , intercalate
+                                                , lookup
+                                                )
+import           Data.Maybe                     ( fromMaybe
+                                                , mapMaybe
+                                                )
 
-import Data.String.Interpolate (i)
-import Data.String.Interpolate.Util (unindent)
+import           Data.String.Interpolate        ( i )
+import           Data.String.Interpolate.Util   ( unindent )
 
-import qualified Data.Text as T
+import qualified Data.Text                     as T
 
-import qualified Data.Time.Calendar.Compat as DT
+import qualified Data.Time.Calendar.Compat     as DT
 
-import qualified Hledger.Data.Transaction as HDT
-import qualified Hledger.Data.Types as HT
+import qualified Hledger.Data.Transaction      as HDT
+import qualified Hledger.Data.Types            as HT
 
-import Text.Printf (printf)
+import           Text.Printf                    ( printf )
 
-import Data.Expenses.Types (Money(..), SimpleTransaction(..))
-import Data.Expenses.Parse.Megaparsec.Entry
-  (Entry(..), entryComment, entryDate, entryPrice, entryRemark)
+import           Data.Expenses.Types            ( Money(..)
+                                                , SimpleTransaction(..)
+                                                )
+import           Data.Expenses.Parse.Megaparsec.Entry
+                                                ( Entry(..)
+                                                , entryComment
+                                                , entryDate
+                                                , entryPrice
+                                                , entryRemark
+                                                )
 
 
 
@@ -41,11 +54,10 @@ moneyFromLedgerAmount :: HT.MixedAmount -> Maybe Money
 moneyFromLedgerAmount (HT.Mixed [a]) =
   -- So, assume: only one amount
   let cur = T.unpack $ HT.acommodity a
-  in Just Amount
-     { moneyAmount = HT.aquantity a
-     , moneyCurrency = Just cur
-     , moneyIsApprox = False
-     }
+  in  Just Amount { moneyAmount   = HT.aquantity a
+                  , moneyCurrency = Just cur
+                  , moneyIsApprox = False
+                  }
 moneyFromLedgerAmount _ = Nothing
 
 
@@ -53,23 +65,23 @@ moneyFromLedgerAmount _ = Nothing
 simpleTransactionFromTransaction :: HT.Transaction -> Maybe SimpleTransaction
 simpleTransactionFromTransaction t =
   let postings = HDT.realPostings t
-  in if length postings == 2 then
-       -- ASSUMPTION: First posting is debit, second posting is credit
-       let description = T.unpack $ HT.tdescription t
-           [debPosting, _credPosting] = postings
-           [debAccount, credAccount] = map (T.unpack . HT.paccount) postings
-           debAmount = HT.pamount debPosting
-       in fmap
-          (\money ->
-             SimpleTransaction
-             { transactionDescription = description
-             , transactionAmount = money
-             , transactionCredittedAccount = credAccount
-             , transactionDebittedAccount = debAccount
-             })
-          (moneyFromLedgerAmount debAmount)
-     else
-       Nothing
+  in  if length postings == 2
+        then
+        -- ASSUMPTION: First posting is debit, second posting is credit
+          let description                = T.unpack $ HT.tdescription t
+              [debPosting, _credPosting] = postings
+              [debAccount, credAccount ] = map (T.unpack . HT.paccount) postings
+              debAmount                  = HT.pamount debPosting
+          in  fmap
+                (\money -> SimpleTransaction
+                  { transactionDescription      = description
+                  , transactionAmount           = money
+                  , transactionCredittedAccount = credAccount
+                  , transactionDebittedAccount  = debAccount
+                  }
+                )
+                (moneyFromLedgerAmount debAmount)
+        else Nothing
 
 
 
@@ -80,29 +92,27 @@ simpleTransactionsInJournal j =
 
 
 directiveFromEntry :: Entry -> String
-directiveFromEntry Entry
-                   { entryDate = _
-                   , entryPrice = price@(dollars, _)
-                   , entryRemark = remark
-                   } =
-  [i|#{direction} #{price'} #{remark}|]
-    where
-      price' = showHumanReadableMoney price
-      direction = if dollars >= 0 then "Spent" else "Received"
+directiveFromEntry Entry { entryDate = _, entryPrice = price@(dollars, _), entryRemark = remark }
+  = [i|#{direction} #{price'} #{remark}|]
+ where
+  price'    = showHumanReadableMoney price
+  direction = if dollars >= 0 then "Spent" else "Received"
 
 
 
 showEntryDate :: Entry -> String
-showEntryDate Entry { entryDate = (y, m, d) } =
-  printf "%4d-%02d-%02d" y m d
+showEntryDate Entry { entryDate = (y, m, d) } = printf "%4d-%02d-%02d" y m d
 
 
 
 showEntryDateWithDay :: Entry -> String
-showEntryDateWithDay Entry { entryDate = (y, m, d) } =
-  printf "%4d-%02d-%02d %s" y m d day
-    where
-      day = show $ DT.dayOfWeek $ DT.fromGregorian (fromIntegral y) m d
+showEntryDateWithDay Entry { entryDate = (y, m, d) } = printf
+  "%4d-%02d-%02d %s"
+  y
+  m
+  d
+  day
+  where day = show $ DT.dayOfWeek $ DT.fromGregorian (fromIntegral y) m d
 
 
 
@@ -111,7 +121,7 @@ showMoney (amount, currency) =
   let (dollars, cents) = properFraction amount
       dollars' = showCommaSeparatedNumber dollars
       cents' = printf "%.02d" (truncate $ cents * 100 :: Integer) :: String
-  in [i|#{dollars'}.#{cents'} #{currency}|]
+  in  [i|#{dollars'}.#{cents'} #{currency}|]
 
 
 
@@ -119,33 +129,40 @@ showCommaSeparatedNumber :: Int -> String
 showCommaSeparatedNumber x | x < 1000 = show x
 showCommaSeparatedNumber x =
   let first = showCommaSeparatedNumber (x `div` 1000)
-      rest = printf "%03d" (x `mod` 1000) :: String
-  in [i|#{first},#{rest}|]
+      rest  = printf "%03d" (x `mod` 1000) :: String
+  in  [i|#{first},#{rest}|]
 
 
 
 showHumanReadableMoney :: (D.Decimal, String) -> String
 showHumanReadableMoney (amount, currency) =
-  let (dollars, cents) = properFraction amount :: (Integer, D.Decimal)
-      trailing3Zeros = dollars `mod` 1000 == 0 && cents == 0
-      useM = dollars > 1000000 && trailing3Zeros
-      useK = dollars > 1000 && (dollars `mod` 1000 == 0 || dollars `mod` 1000 >= 100) && cents == 0
-      (dollars', cents', modifier)
-        | useM =
-          ( dollars `div` 1000000
-          , D.Decimal 3 $ (dollars `mod` 1000000) `div` 1000
-          , "m"
-          )
-        | useK =
-            (dollars `div` 1000, D.Decimal 3 $ dollars `mod` 1000, "k")
-        | otherwise =
-            (dollars, cents, "")
-      humanReadableDollars = showCommaSeparatedNumber $ fromIntegral dollars'
-      humanReadableCents
-        | cents' == 0 = ""
-        | useM || useK = drop 1 $ show $ D.normalizeDecimal cents'
-        | otherwise = drop 1 $ show cents'
-  in [i|#{humanReadableDollars}#{humanReadableCents}#{modifier} #{currency}|]
+  let
+    (dollars, cents) = properFraction amount :: (Integer, D.Decimal)
+    trailing3Zeros   = dollars `mod` 1000 == 0 && cents == 0
+    useM             = dollars > 1000000 && trailing3Zeros
+    useK =
+      dollars
+        >  1000
+        && (dollars `mod` 1000 == 0 || dollars `mod` 1000 >= 100)
+        && cents
+        == 0
+    (dollars', cents', modifier)
+      | useM
+      = ( dollars `div` 1000000
+        , D.Decimal 3 $ (dollars `mod` 1000000) `div` 1000
+        , "m"
+        )
+      | useK
+      = (dollars `div` 1000, D.Decimal 3 $ dollars `mod` 1000, "k")
+      | otherwise
+      = (dollars, cents, "")
+    humanReadableDollars = showCommaSeparatedNumber $ fromIntegral dollars'
+    humanReadableCents
+      | cents' == 0  = ""
+      | useM || useK = drop 1 $ show $ D.normalizeDecimal cents'
+      | otherwise    = drop 1 $ show cents'
+  in
+    [i|#{humanReadableDollars}#{humanReadableCents}#{modifier} #{currency}|]
 
 
 
@@ -160,20 +177,20 @@ showLedgerTransactionFromEntry entry account =
   # #{originalDirective}
   #{date} #{remark}
     #{account}  #{price}
-    Assets:Cash:#{cur}|] ++ cmt
-  where
-    date   = showEntryDate entry
-    (_, cur) = entryPrice entry
-    price = showEntryPrice entry
-    remark = entryRemark entry
-    cmt = maybe "" ((:) '\n') $ entryComment entry
-    originalDirective = directiveFromEntry entry
+    Assets:Cash:#{cur}|]
+    ++ cmt
+ where
+  date              = showEntryDate entry
+  (_, cur)          = entryPrice entry
+  price             = showEntryPrice entry
+  remark            = entryRemark entry
+  cmt               = maybe "" ((:) '\n') $ entryComment entry
+  originalDirective = directiveFromEntry entry
 
 
 
 equalBy :: Eq b => (a -> b) -> (a -> a -> Bool)
-equalBy f a1 a2 =
-  f a1 == f a2
+equalBy f a1 a2 = f a1 == f a2
 
 
 
@@ -182,12 +199,13 @@ showLedgerJournalFromEntries entries accountForEntry =
   let groupedEntries = groupBy (equalBy entryDate) entries
       journalForDay :: [Entry] -> String
       journalForDay es =
-        let dateComment = [i|# #{showEntryDateWithDay $ head es}|]
-            transactions = unlines $ map (\e -> showLedgerTransactionFromEntry e $ accountForEntry e) es
-        in dateComment ++ "\n" ++ transactions
+          let dateComment  = [i|# #{showEntryDateWithDay $ head es}|]
+              transactions = unlines $ map
+                (\e -> showLedgerTransactionFromEntry e $ accountForEntry e)
+                es
+          in  dateComment ++ "\n" ++ transactions
       journalParts = map journalForDay groupedEntries
-
-  in intercalate "\n" journalParts
+  in  intercalate "\n" journalParts
 
 
 

--- a/src/Data/Expenses/Ledger/AccountSuggestions.hs
+++ b/src/Data/Expenses/Ledger/AccountSuggestions.hs
@@ -1,14 +1,15 @@
 module Data.Expenses.Ledger.AccountSuggestions
   ( SuggestionResult(..)
   , suggestions
-  ) where
+  )
+where
 
-import qualified Data.List as L
-import qualified Data.List.NonEmpty as NE
+import qualified Data.List                     as L
+import qualified Data.List.NonEmpty            as NE
 
 
-import qualified Data.TagFrequencies as TF
-import Data.Expenses.Types (SimpleTransaction(..))
+import qualified Data.TagFrequencies           as TF
+import           Data.Expenses.Types            ( SimpleTransaction(..) )
 
 
 
@@ -22,29 +23,23 @@ data SuggestionResult
 
 addTransaction :: SimpleTransaction -> TF.Table -> TF.Table
 addTransaction txn tbl =
-  let
-    phrase = transactionDescription txn
-    tag = transactionDebittedAccount txn
-  in
-    TF.addPhrase phrase tag tbl
+  let phrase = transactionDescription txn
+      tag    = transactionDebittedAccount txn
+  in  TF.addPhrase phrase tag tbl
 
 
 
 frequencyTableForTransactions :: [SimpleTransaction] -> TF.Table
-frequencyTableForTransactions =
-  L.foldr addTransaction TF.empty
+frequencyTableForTransactions = L.foldr addTransaction TF.empty
 
 
 
 suggestions :: [SimpleTransaction] -> String -> SuggestionResult
 suggestions txns description =
-  let
-    tbl = frequencyTableForTransactions txns
-  in
-  case TF.tagsForExactPhrase description tbl of
-    Nothing ->
-      case TF.tagsByWords description tbl of
-        [] -> None
-        accounts -> Ambiguous $ NE.fromList accounts
-    Just [account] -> Exact account
-    Just accounts -> Ambiguous $ NE.fromList accounts
+  let tbl = frequencyTableForTransactions txns
+  in  case TF.tagsForExactPhrase description tbl of
+        Nothing -> case TF.tagsByWords description tbl of
+          []       -> None
+          accounts -> Ambiguous $ NE.fromList accounts
+        Just [account] -> Exact account
+        Just accounts  -> Ambiguous $ NE.fromList accounts

--- a/src/Data/Expenses/Ledger/Process.hs
+++ b/src/Data/Expenses/Ledger/Process.hs
@@ -1,19 +1,21 @@
 module Data.Expenses.Ledger.Process
   ( xmlOf
   , xmlOfString
-  ) where
+  )
+where
 
-import qualified Data.ByteString.Lazy.Char8 as LBS8
+import qualified Data.ByteString.Lazy.Char8    as LBS8
 
-import qualified System.Process.Typed as TP
+import qualified System.Process.Typed          as TP
 
 
 
 xmlOf :: FilePath -> IO String
 xmlOf journal = do
-  let ledgerConfig = TP.setStdin TP.nullStream
-                   $ TP.setStdout TP.byteStringOutput
-                   $ TP.proc "ledger" ["xml", "-f", journal]
+  let ledgerConfig =
+        TP.setStdin TP.nullStream $ TP.setStdout TP.byteStringOutput $ TP.proc
+          "ledger"
+          ["xml", "-f", journal]
   (_, stdout, _) <- TP.readProcess ledgerConfig
   return $ LBS8.unpack stdout
 
@@ -21,8 +23,9 @@ xmlOf journal = do
 
 xmlOfString :: String -> IO String
 xmlOfString journal = do
-  let ledgerConfig = TP.setStdin (TP.byteStringInput $ LBS8.pack journal)
-                   $ TP.setStdout TP.byteStringOutput
-                   $ TP.proc "ledger" ["xml", "-f", "-"]
+  let ledgerConfig =
+        TP.setStdin (TP.byteStringInput $ LBS8.pack journal)
+          $ TP.setStdout TP.byteStringOutput
+          $ TP.proc "ledger" ["xml", "-f", "-"]
   (_, stdout, _) <- TP.readProcess ledgerConfig
   return $ LBS8.unpack stdout

--- a/src/Data/Expenses/Parse/Megaparsec/DateDirective.hs
+++ b/src/Data/Expenses/Parse/Megaparsec/DateDirective.hs
@@ -10,18 +10,32 @@
 --  (also TUES, WEDS)
 
 module Data.Expenses.Parse.Megaparsec.DateDirective
-  (date, dateDirective, dayOfWeek) where
+  ( date
+  , dateDirective
+  , dayOfWeek
+  )
+where
 
-import Control.Monad (void)
+import           Control.Monad                  ( void )
 
-import qualified Data.Time.Calendar.Compat as DT
+import qualified Data.Time.Calendar.Compat     as DT
 
-import Text.Megaparsec
-  (choice, hidden, noneOf, option, optional, skipMany)
-import Text.Megaparsec.Char (spaceChar, string)
-import qualified Text.Megaparsec.Char.Lexer as L
+import           Text.Megaparsec                ( choice
+                                                , hidden
+                                                , noneOf
+                                                , option
+                                                , optional
+                                                , skipMany
+                                                )
+import           Text.Megaparsec.Char           ( spaceChar
+                                                , string
+                                                )
+import qualified Text.Megaparsec.Char.Lexer    as L
 
-import Data.Expenses.Parse.Megaparsec.Types (Parser, DateDirective(..))
+import           Data.Expenses.Parse.Megaparsec.Types
+                                                ( Parser
+                                                , DateDirective(..)
+                                                )
 
 
 
@@ -46,36 +60,34 @@ dash = symbol "-"
 
 
 dayOfWeek :: Parser DT.DayOfWeek
-dayOfWeek =
-  choice
-    [ DT.Monday <$ string "MON"
-    , DT.Tuesday <$ (string "TUE" <* skipMany (noneOf "\n\r\0"))
-    , DT.Wednesday <$ (string "WED" <* skipMany (noneOf "\n\r\0"))
-    , DT.Thursday <$ (string "THU" <* skipMany (noneOf "\n\r\0"))
-    , DT.Friday <$ string "FRI"
-    , DT.Saturday <$ string "SAT"
-    , DT.Sunday <$ string "SUN"
-    ]
+dayOfWeek = choice
+  [ DT.Monday <$ string "MON"
+  , DT.Tuesday <$ (string "TUE" <* skipMany (noneOf "\n\r\0"))
+  , DT.Wednesday <$ (string "WED" <* skipMany (noneOf "\n\r\0"))
+  , DT.Thursday <$ (string "THU" <* skipMany (noneOf "\n\r\0"))
+  , DT.Friday <$ string "FRI"
+  , DT.Saturday <$ string "SAT"
+  , DT.Sunday <$ string "SUN"
+  ]
 
 
 
 date :: Parser DT.Day
-date =
-  do yyyy <- integer
-     void  dash
-     mm <- fromIntegral <$> integer
-     void  dash
-     dd <- fromIntegral <$> integer
-     return $ DT.fromGregorian yyyy mm dd
+date = do
+  yyyy <- integer
+  void dash
+  mm <- fromIntegral <$> integer
+  void dash
+  dd <- fromIntegral <$> integer
+  return $ DT.fromGregorian yyyy mm dd
 
 
 
 dateDirective :: Parser DateDirective
-dateDirective =
-  do dt <- optional date
-     case dt of
-       Just day -> do
-         dow <- option (DT.dayOfWeek day) dayOfWeek
-         return $ DateDir dt dow
-       Nothing ->
-         DateDir dt <$> dayOfWeek
+dateDirective = do
+  dt <- optional date
+  case dt of
+    Just day -> do
+      dow <- option (DT.dayOfWeek day) dayOfWeek
+      return $ DateDir dt dow
+    Nothing -> DateDir dt <$> dayOfWeek

--- a/src/Data/Expenses/Parse/Megaparsec/Document.hs
+++ b/src/Data/Expenses/Parse/Megaparsec/Document.hs
@@ -2,46 +2,59 @@ module Data.Expenses.Parse.Megaparsec.Document
   ( modelFromAst
   , parseExpensesFile
   , withFile
-  ) where
-
-import Control.Monad (forM_, void)
-
-import Data.Void (Void)
-
-import Data.Either (Either(..), partitionEithers)
-
-import qualified Data.Time.Calendar.Compat as DT
-
-import Text.Megaparsec
-  ( ParseError
-  , anySingle
-  , between
-  , choice
-  , eof
-  , errorBundlePretty
-  , hidden
-  , manyTill
-  , parseErrorPretty
-  , runParser
-  , sepEndBy
-  , skipMany
-  , someTill
-  , try
-  , withRecovery
-  , (<?>)
-  , (<|>)
   )
-import Text.Megaparsec.Char (eol, spaceChar)
-import qualified Text.Megaparsec.Char.Lexer as L
+where
 
-import Data.Expenses.Parse.Megaparsec.Entry
-import Data.Expenses.Parse.Megaparsec.Types
-  (AST(..), LineDirective(..), Parser, RawLineDirective)
-import qualified Data.Expenses.Parse.Megaparsec.DateDirective as PD
-import qualified Data.Expenses.Parse.Megaparsec.ExpenseDirective as PE
-import Data.Expenses.Expense
-  (nextDate)
-import Data.Expenses.Types (Model, modelFromEntries)
+import           Control.Monad                  ( forM_
+                                                , void
+                                                )
+
+import           Data.Void                      ( Void )
+
+import           Data.Either                    ( Either(..)
+                                                , partitionEithers
+                                                )
+
+import qualified Data.Time.Calendar.Compat     as DT
+
+import           Text.Megaparsec                ( ParseError
+                                                , anySingle
+                                                , between
+                                                , choice
+                                                , eof
+                                                , errorBundlePretty
+                                                , hidden
+                                                , manyTill
+                                                , parseErrorPretty
+                                                , runParser
+                                                , sepEndBy
+                                                , skipMany
+                                                , someTill
+                                                , try
+                                                , withRecovery
+                                                , (<?>)
+                                                , (<|>)
+                                                )
+import           Text.Megaparsec.Char           ( eol
+                                                , spaceChar
+                                                )
+import qualified Text.Megaparsec.Char.Lexer    as L
+
+import           Data.Expenses.Parse.Megaparsec.Entry
+import           Data.Expenses.Parse.Megaparsec.Types
+                                                ( AST(..)
+                                                , LineDirective(..)
+                                                , Parser
+                                                , RawLineDirective
+                                                )
+import qualified Data.Expenses.Parse.Megaparsec.DateDirective
+                                               as PD
+import qualified Data.Expenses.Parse.Megaparsec.ExpenseDirective
+                                               as PE
+import           Data.Expenses.Expense          ( nextDate )
+import           Data.Expenses.Types            ( Model
+                                                , modelFromEntries
+                                                )
 
 
 
@@ -51,37 +64,28 @@ import Data.Expenses.Types (Model, modelFromEntries)
 
 
 scn :: Parser ()
-scn = hidden . skipMany $ choice [ void spaceChar
-                                 , L.skipLineComment "#"
-                                 ]
+scn = hidden . skipMany $ choice [void spaceChar, L.skipLineComment "#"]
 
 
 
 lineDirective :: Parser LineDirective
 lineDirective =
-  (DateCmd
-   <$> PD.dateDirective <* scn
-   <?> "Date directive") <|>
-  (ExpCmd
-   <$> PE.expense <* scn
-   <?> "Expense directive")
+  (DateCmd <$> PD.dateDirective <* scn <?> "Date directive")
+    <|> (ExpCmd <$> PE.expense <* scn <?> "Expense directive")
 
 
 
 recover :: ParseError String Void -> Parser RawLineDirective
-recover err =
-  Left err <$ (try restOfLine <|> lastLine)
-    where
-      restOfLine = void $ manyTill anySingle eol
-      lastLine = void $ someTill (void anySingle) eof
+recover err = Left err <$ (try restOfLine <|> lastLine)
+ where
+  restOfLine = void $ manyTill anySingle eol
+  lastLine   = void $ someTill (void anySingle) eof
 
 
 
 parseExpensesFile :: Parser AST
-parseExpensesFile =
-  AST <$> between scn eof (sepEndBy rawLine scn)
-   where
-     rawLine = withRecovery recover (Right <$> lineDirective)
+parseExpensesFile = AST <$> between scn eof (sepEndBy rawLine scn)
+  where rawLine = withRecovery recover (Right <$> lineDirective)
 
 
 
@@ -90,54 +94,45 @@ parseExpensesFile =
 
 
 modelFromAst :: AST -> Either [ParseError String Void] Model
-modelFromAst (AST eitherLineDirectives) =
-  f partitionedEitherDirectives
-    where
+modelFromAst (AST eitherLineDirectives) = f partitionedEitherDirectives
+ where
   f ([], lineDirectives) =
     Right (modelFromEntries $ entriesFromDirectives lineDirectives)
-  f (parseErrors, _) =
-    Left parseErrors
+  f (parseErrors, _) = Left parseErrors
   partitionedEitherDirectives = partitionEithers eitherLineDirectives
 
 
 
 entriesFromDirectives :: [LineDirective] -> [Entry]
 entriesFromDirectives directives =
-  let
-    initial = ((-1, -1, -1), DT.Monday, [])
+  let initial               = ((-1, -1, -1), DT.Monday, [])
 
-    -- Fold over a (Date, Day, GatheredRows)
-    (_, _, directiveRows) =
-      foldl (\(date, day, rows) lineD ->
-               case lineD of
-                 -- For ExpenseDirectives, simply add to list of 'rows'.
-                 ExpCmd expense ->
-                   (date, day, entryFromExpense date expense : rows)
+      -- Fold over a (Date, Day, GatheredRows)
+      (_, _, directiveRows) = foldl
+        (\(date, day, rows) lineD -> case lineD of
+                   -- For ExpenseDirectives, simply add to list of 'rows'.
+          ExpCmd expense -> (date, day, entryFromExpense date expense : rows)
 
-                 -- For DateDirectives, increment/set the date/day.
-                 DateCmd dateDir ->
-                   let (date', day') = nextDate (date, day) dateDir
-                   in  (date', day', rows))
-            initial
-            directives
-    rows' = reverse directiveRows
-  in
-  rows'
+          -- For DateDirectives, increment/set the date/day.
+          DateCmd dateDir ->
+            let (date', day') = nextDate (date, day) dateDir
+            in  (date', day', rows)
+        )
+        initial
+        directives
+      rows' = reverse directiveRows
+  in  rows'
 
 
 
-withFile :: String -> (Model -> IO()) -> IO ()
+withFile :: String -> (Model -> IO ()) -> IO ()
 withFile inputF f = do
   -- Parse the input file to list of [DateDir | ExpDir]
   rawResult <- runParser parseExpensesFile inputF <$> readFile inputF
 
   case rawResult of
-    Left err ->
-      putStrLn $ errorBundlePretty err
+    Left  err    -> putStrLn $ errorBundlePretty err
 
-    Right result ->
-      case modelFromAst result of
-        Left errors ->
-          forM_ errors $ putStrLn . parseErrorPretty
-        Right directives ->
-          f directives
+    Right result -> case modelFromAst result of
+      Left  errors     -> forM_ errors $ putStrLn . parseErrorPretty
+      Right directives -> f directives

--- a/src/Data/Expenses/Parse/Megaparsec/Entry.hs
+++ b/src/Data/Expenses/Parse/Megaparsec/Entry.hs
@@ -4,28 +4,32 @@ module Data.Expenses.Parse.Megaparsec.Entry
   )
 where
 
-import Data.Maybe (fromMaybe)
+import           Data.Maybe                     ( fromMaybe )
 
-import qualified Data.Expenses.Types as E
-import Data.Expenses.Types (Entry(..))
-import qualified Data.Expenses.Parse.Megaparsec.Types as PE
-import Data.Expenses.Parse.Megaparsec.Types (Direction(..), Expense(..))
+import qualified Data.Expenses.Types           as E
+import           Data.Expenses.Types            ( Entry(..) )
+import qualified Data.Expenses.Parse.Megaparsec.Types
+                                               as PE
+import           Data.Expenses.Parse.Megaparsec.Types
+                                                ( Direction(..)
+                                                , Expense(..)
+                                                )
 
 
 
 entryFromExpense :: (Int, Int, Int) -> Expense -> Entry
-entryFromExpense (y, m, d) expense =
-  Entry { entryDate       = (y, m, d)
-        , entryPrice      = (value, cur)
-        , entryRemark     = PE.expenseRemark expense
-        , entryComment    = PE.expenseComment expense
-        }
-  where
-    amount  = PE.expenseAmount expense
-    mult    = case PE.expenseDirection expense of
-               Spent -> (1 *)
-               Received -> ((-1) *)
-    value = mult $ E.moneyAmount amount
+entryFromExpense (y, m, d) expense = Entry
+  { entryDate    = (y, m, d)
+  , entryPrice   = (value, cur)
+  , entryRemark  = PE.expenseRemark expense
+  , entryComment = PE.expenseComment expense
+  }
+ where
+  amount = PE.expenseAmount expense
+  mult   = case PE.expenseDirection expense of
+    Spent    -> (1 *)
+    Received -> ((-1) *)
+  value = mult $ E.moneyAmount amount
 
-    -- MAGIC: Implicit currency is SGD if not given.
-    cur     = fromMaybe "SGD" (E.moneyCurrency amount)
+  -- MAGIC: Implicit currency is SGD if not given.
+  cur   = fromMaybe "SGD" (E.moneyCurrency amount)

--- a/src/Data/Expenses/Parse/Megaparsec/ExpenseDirective.hs
+++ b/src/Data/Expenses/Parse/Megaparsec/ExpenseDirective.hs
@@ -10,52 +10,62 @@
 -- at this point. (e.g. "location").
 
 module Data.Expenses.Parse.Megaparsec.ExpenseDirective
-  (amount, direction, dollarsAndCents, expense, shiftDecimalPlaces) where
-
-import Control.Monad (void)
-
-import qualified Data.Decimal as D
-
-import Data.List (intercalate)
-
-import Data.Maybe (fromMaybe, isJust)
-
-import qualified Data.List.NonEmpty as NE
-
-import qualified Data.Set as Set
-
-
-import Text.Megaparsec
-  ( ErrorItem(Tokens)
-  , anySingle
-  , choice
-  , count
-  , eof
-  , failure
-  , hidden
-  , lookAhead
-  , many
-  , noneOf
-  , optional
-  , skipMany
-  , some
-  , someTill
-  , try
-  , (<|>)
+  ( amount
+  , direction
+  , dollarsAndCents
+  , expense
+  , shiftDecimalPlaces
   )
-import Text.Megaparsec.Char
-  ( char
-  , letterChar
-  , string
-  , tab
-  , upperChar
-  )
-import qualified Text.Megaparsec.Char as C
-import qualified Text.Megaparsec.Char.Lexer as L
+where
 
-import Data.Expenses.Types (Money(..))
+import           Control.Monad                  ( void )
 
-import Data.Expenses.Parse.Megaparsec.Types (Direction(..), Expense(..), Parser)
+import qualified Data.Decimal                  as D
+
+import           Data.List                      ( intercalate )
+
+import           Data.Maybe                     ( fromMaybe
+                                                , isJust
+                                                )
+
+import qualified Data.List.NonEmpty            as NE
+
+import qualified Data.Set                      as Set
+
+
+import           Text.Megaparsec                ( ErrorItem(Tokens)
+                                                , anySingle
+                                                , choice
+                                                , count
+                                                , eof
+                                                , failure
+                                                , hidden
+                                                , lookAhead
+                                                , many
+                                                , noneOf
+                                                , optional
+                                                , skipMany
+                                                , some
+                                                , someTill
+                                                , try
+                                                , (<|>)
+                                                )
+import           Text.Megaparsec.Char           ( char
+                                                , letterChar
+                                                , string
+                                                , tab
+                                                , upperChar
+                                                )
+import qualified Text.Megaparsec.Char          as C
+import qualified Text.Megaparsec.Char.Lexer    as L
+
+import           Data.Expenses.Types            ( Money(..) )
+
+import           Data.Expenses.Parse.Megaparsec.Types
+                                                ( Direction(..)
+                                                , Expense(..)
+                                                , Parser
+                                                )
 
 
 
@@ -77,62 +87,62 @@ direction :: Parser Direction
 direction = do
   word <- lookAhead $ many letterChar :: Parser String
   case word of
-    "Spent" -> Spent <$ ((string "Spent" :: Parser String) *> sc)
+    "Spent"    -> Spent <$ ((string "Spent" :: Parser String) *> sc)
     "Received" -> Received <$ ((string "Received" :: Parser String) *> sc)
-    _ -> failure (Just $ Tokens $ NE.fromList word)
-                 (Set.fromList [ Tokens (NE.fromList "Spent")
-                               , Tokens (NE.fromList "Received")
-                               ])
+    _          -> failure
+      (Just $ Tokens $ NE.fromList word)
+      (Set.fromList
+        [Tokens (NE.fromList "Spent"), Tokens (NE.fromList "Received")]
+      )
 
 
 
 currency :: Parser String
-currency =
-  lexeme $ count 3 upperChar
+currency = lexeme $ count 3 upperChar
 
 
 
 dollarsAndCents :: Parser D.Decimal
-dollarsAndCents =
-  do dollarsString <- some (skipMany (C.char ',') *> C.digitChar)
-     centsString <- try (C.char '.' *> (Just <$> some C.digitChar <* sc)) <|>
-                        Nothing <$ sc
-     let centsLength = fromIntegral $ maybe 0 length centsString
-         number = read $ dollarsString ++ fromMaybe "" centsString
-     return $ D.Decimal centsLength number
+dollarsAndCents = do
+  dollarsString <- some (skipMany (C.char ',') *> C.digitChar)
+  centsString   <-
+    try (C.char '.' *> (Just <$> some C.digitChar <* sc)) <|> Nothing <$ sc
+  let centsLength = fromIntegral $ maybe 0 length centsString
+      number      = read $ dollarsString ++ fromMaybe "" centsString
+  return $ D.Decimal centsLength number
 
 
 
 shiftDecimalPlaces :: Int -> D.Decimal -> D.Decimal
 shiftDecimalPlaces mul value =
-  let places = D.decimalPlaces value
-      mantissa = D.decimalMantissa value
-      mul' = fromIntegral mul - places
-      value' = D.Decimal
-                { D.decimalPlaces = 0
-                , D.decimalMantissa =  (10 ^ mul') * mantissa
-                }
-  in value'
+  let
+    places   = D.decimalPlaces value
+    mantissa = D.decimalMantissa value
+    mul'     = fromIntegral mul - places
+    value'   = D.Decimal { D.decimalPlaces   = 0
+                         , D.decimalMantissa = (10 ^ mul') * mantissa
+                         }
+  in
+    value'
 
 
 
 amount :: Parser Money
-amount =
-  do approx <- optional $ symbol "~"
-     -- (dollars, cents) <- dollarsAndCents
-     value <- dollarsAndCents
-     let kModifier = 3 <$ C.char 'k'
-         mModifier = 6 <$ C.char 'm'
-     modifier <- optional $ (kModifier <|> mModifier) <* sc
-     cur <- optional currency
-     void sc
-     -- return $ Amount dollars cents cur (isJust approx)
-     return $ case modifier of
-       Nothing -> Amount value cur (isJust approx)
-       Just mul ->
-         let value' = shiftDecimalPlaces mul value
-         in
-           Amount value' cur (isJust approx)
+amount = do
+  approx <- optional $ symbol "~"
+  -- (dollars, cents) <- dollarsAndCents
+  value  <- dollarsAndCents
+  let kModifier = 3 <$ C.char 'k'
+      mModifier = 6 <$ C.char 'm'
+  modifier <- optional $ (kModifier <|> mModifier) <* sc
+  cur      <- optional currency
+  void sc
+  -- return $ Amount dollars cents cur (isJust approx)
+  return $ case modifier of
+    Nothing -> Amount value cur (isJust approx)
+    Just mul ->
+      let value' = shiftDecimalPlaces mul value
+      in  Amount value' cur (isJust approx)
 
 
 
@@ -142,21 +152,20 @@ commentOnNextLine = do
   void C.newline
   c <- C.char '#'
   s <- someTill anySingle (lookAhead (void C.eol <|> eof))
-  return (c:s)
+  return (c : s)
 
 
 
 commentsOnFollowingLines :: Parser String
-commentsOnFollowingLines =
-  intercalate "\n" <$> some (try commentOnNextLine)
+commentsOnFollowingLines = intercalate "\n" <$> some (try commentOnNextLine)
 
 
 
 -- n.b. this doesn't allow for comments at the end-of-line
 expense :: Parser Expense
-expense =
-  do dir <- direction
-     am  <- amount
-     remark <- many (noneOf "\n\r\0")
-     comment <- optional commentsOnFollowingLines
-     return $ Expense dir am remark comment
+expense = do
+  dir     <- direction
+  am      <- amount
+  remark  <- many (noneOf "\n\r\0")
+  comment <- optional commentsOnFollowingLines
+  return $ Expense dir am remark comment

--- a/src/Data/Expenses/Parse/Megaparsec/Types.hs
+++ b/src/Data/Expenses/Parse/Megaparsec/Types.hs
@@ -6,15 +6,20 @@ module Data.Expenses.Parse.Megaparsec.Types
   , Parser
   , LineDirective(..)
   , RawLineDirective
-  ) where
+  )
+where
 
-import Data.Time.Calendar.Compat (Day, DayOfWeek)
+import           Data.Time.Calendar.Compat      ( Day
+                                                , DayOfWeek
+                                                )
 
-import Data.Void (Void)
+import           Data.Void                      ( Void )
 
-import Text.Megaparsec (ParseError, Parsec)
+import           Text.Megaparsec                ( ParseError
+                                                , Parsec
+                                                )
 
-import Data.Expenses.Types (Money)
+import           Data.Expenses.Types            ( Money )
 
 
 

--- a/src/Data/Expenses/Query.hs
+++ b/src/Data/Expenses/Query.hs
@@ -1,23 +1,25 @@
-module Data.Expenses.Query (attr, queryDirectives) where
+module Data.Expenses.Query
+  ( attr
+  , queryDirectives
+  )
+where
 
-import Text.Printf (printf)
+import           Text.Printf                    ( printf )
 
-import Data.Expenses.Types (Entry(..), QueryAttribute(..))
+import           Data.Expenses.Types            ( Entry(..)
+                                                , QueryAttribute(..)
+                                                )
 
 
 attr :: String -> Maybe QueryAttribute
 attr "earliest" = Just Earliest
-attr "latest" = Just Latest
-attr _ = Nothing
+attr "latest"   = Just Latest
+attr _          = Nothing
 
 
 
 queryDirectives :: QueryAttribute -> [Entry] -> String
-queryDirectives Earliest entries =
-  printf "%4d-%02d-%02d" y m d
-    where
-      (y, m, d) = entryDate $ head entries
-queryDirectives Latest entries =
-  printf "%4d-%02d-%02d" y m d
-    where
-      (y, m, d) = entryDate $ last entries
+queryDirectives Earliest entries = printf "%4d-%02d-%02d" y m d
+  where (y, m, d) = entryDate $ head entries
+queryDirectives Latest entries = printf "%4d-%02d-%02d" y m d
+  where (y, m, d) = entryDate $ last entries

--- a/src/Data/Expenses/ToCSV.hs
+++ b/src/Data/Expenses/ToCSV.hs
@@ -1,26 +1,31 @@
-module Data.Expenses.ToCSV (recordsFromEntries) where
+module Data.Expenses.ToCSV
+  ( recordsFromEntries
+  )
+where
 
-import Text.CSV as CSV
+import           Text.CSV                      as CSV
 
-import Text.Printf (printf)
+import           Text.Printf                    ( printf )
 
-import Data.Expenses.Parse.Megaparsec.Entry
-  (Entry, entryDate, entryPrice, entryRemark)
+import           Data.Expenses.Parse.Megaparsec.Entry
+                                                ( Entry
+                                                , entryDate
+                                                , entryPrice
+                                                , entryRemark
+                                                )
 
 
 
 recordFromEntry :: Entry -> CSV.Record
-recordFromEntry entry =
-  [date, price, cur, remark]
-  where
-    (y, m, d) = entryDate entry
-    date   = printf "%4d-%02d-%02d" y m d
-    (amount', cur) = entryPrice entry
-    price  = show amount'
-    remark = entryRemark entry
+recordFromEntry entry = [date, price, cur, remark]
+ where
+  (y, m, d)      = entryDate entry
+  date           = printf "%4d-%02d-%02d" y m d
+  (amount', cur) = entryPrice entry
+  price          = show amount'
+  remark         = entryRemark entry
 
 
 
 recordsFromEntries :: [Entry] -> [CSV.Record]
-recordsFromEntries =
-  map recordFromEntry
+recordsFromEntries = map recordFromEntry

--- a/src/Data/Expenses/Types.hs
+++ b/src/Data/Expenses/Types.hs
@@ -6,9 +6,10 @@ module Data.Expenses.Types
   , SimpleTransaction(..)
   , entriesFromModel
   , modelFromEntries
-  ) where
+  )
+where
 
-import qualified Data.Decimal as D
+import qualified Data.Decimal                  as D
 
 
 
@@ -59,6 +60,5 @@ data SimpleTransaction = SimpleTransaction
   } deriving (Show, Eq)
 
 instance Ord SimpleTransaction where
-  compare SimpleTransaction { transactionDescription = a }
-          SimpleTransaction { transactionDescription = b } =
-    compare a b
+  compare SimpleTransaction { transactionDescription = a } SimpleTransaction { transactionDescription = b }
+    = compare a b

--- a/src/Data/TagFrequencies.hs
+++ b/src/Data/TagFrequencies.hs
@@ -4,13 +4,14 @@ module Data.TagFrequencies
   , addPhrase
   , tagsForExactPhrase
   , tagsByWords
-  ) where
+  )
+where
 
-import qualified Data.List as L
-import qualified Data.List.NonEmpty as NE
+import qualified Data.List                     as L
+import qualified Data.List.NonEmpty            as NE
 
-import qualified Data.Map.Strict as M
-import qualified Data.Set as S
+import qualified Data.Map.Strict               as M
+import qualified Data.Set                      as S
 
 
 
@@ -32,63 +33,50 @@ data Table =
 
 
 empty :: Table
-empty =
-  FrequencyTable
-    { tableAllTags = M.empty
-    , tablePhraseTags = M.empty
-    , tableWordTags = M.empty
-    }
+empty = FrequencyTable { tableAllTags    = M.empty
+                       , tablePhraseTags = M.empty
+                       , tableWordTags   = M.empty
+                       }
 
 
 
 addPhrase :: String -> String -> Table -> Table
 addPhrase phrase tag tbl =
-  let
-    incr k = M.insertWith (+) k 1
-    allTags' = incr tag $ tableAllTags tbl
-    addTagForKey k =
-      M.insertWith (M.unionWith (+)) k (M.singleton tag 1)
-    phraseTags' = addTagForKey phrase $ tablePhraseTags tbl
-    phraseWords = L.words phrase
-    wordTags' =
-      L.foldr addTagForKey (tableWordTags tbl) phraseWords
-  in
-    FrequencyTable
-      { tableAllTags = allTags'
-      , tablePhraseTags = phraseTags'
-      , tableWordTags = wordTags'
-      }
+  let incr k = M.insertWith (+) k 1
+      allTags' = incr tag $ tableAllTags tbl
+      addTagForKey k = M.insertWith (M.unionWith (+)) k (M.singleton tag 1)
+      phraseTags' = addTagForKey phrase $ tablePhraseTags tbl
+      phraseWords = L.words phrase
+      wordTags'   = L.foldr addTagForKey (tableWordTags tbl) phraseWords
+  in  FrequencyTable { tableAllTags    = allTags'
+                     , tablePhraseTags = phraseTags'
+                     , tableWordTags   = wordTags'
+                     }
 
 
 
 tagsByFrequency :: M.Map String Int -> [String]
 tagsByFrequency frequencies =
-  let
-    xs = M.toList frequencies
-  in
-  L.map snd $ L.sort $ L.map (\(k,c) -> (-c,k)) xs
+  let xs = M.toList frequencies
+  in  L.map snd $ L.sort $ L.map (\(k, c) -> (-c, k)) xs
 
 
 
 frequenciesForPhrase :: String -> Table -> Maybe (M.Map String Int)
-frequenciesForPhrase phrase tbl =
-  M.lookup phrase $ tablePhraseTags tbl
+frequenciesForPhrase phrase tbl = M.lookup phrase $ tablePhraseTags tbl
 
 
 
-frequenciesForWords
-  :: String -> Table -> M.Map String Int
+frequenciesForWords :: String -> Table -> M.Map String Int
 frequenciesForWords phrase tbl =
-  let
-    phraseWords = words phrase
-    wordsSet = S.fromList phraseWords
-    wordTagFrequencies = M.restrictKeys (tableWordTags tbl) wordsSet
-  in
-  if M.null wordTagFrequencies then
-    -- No words intersect; so use tags from all words
-    tableAllTags tbl
-  else
-    M.foldr (M.unionWith (+)) M.empty wordTagFrequencies
+  let phraseWords        = words phrase
+      wordsSet           = S.fromList phraseWords
+      wordTagFrequencies = M.restrictKeys (tableWordTags tbl) wordsSet
+  in  if M.null wordTagFrequencies
+        then
+        -- No words intersect; so use tags from all words
+             tableAllTags tbl
+        else M.foldr (M.unionWith (+)) M.empty wordTagFrequencies
 
 
 
@@ -99,5 +87,4 @@ tagsForExactPhrase phrase tbl =
 
 
 tagsByWords :: String -> Table -> [String]
-tagsByWords phrase tbl =
-  tagsByFrequency $ frequenciesForWords phrase tbl
+tagsByWords phrase tbl = tagsByFrequency $ frequenciesForWords phrase tbl

--- a/src/Main/CmdArgs.hs
+++ b/src/Main/CmdArgs.hs
@@ -1,24 +1,27 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 
-module Main.CmdArgs (ExpensesCmd(..), run) where
+module Main.CmdArgs
+  ( ExpensesCmd(..)
+  , run
+  )
+where
 
-import Data.Data (Data)
-import Data.Typeable (Typeable)
+import           Data.Data                      ( Data )
+import           Data.Typeable                  ( Typeable )
 
-import System.Console.CmdArgs
-   ( (&=)
-   , CmdArgs
-   , Mode
-   , argPos
-   , cmdArgsMode
-   , cmdArgsRun
-   , def
-   , help
-   , modes
-   , program
-   , summary
-   , typ
-   )
+import           System.Console.CmdArgs         ( (&=)
+                                                , CmdArgs
+                                                , Mode
+                                                , argPos
+                                                , cmdArgsMode
+                                                , cmdArgsRun
+                                                , def
+                                                , help
+                                                , modes
+                                                , program
+                                                , summary
+                                                , typ
+                                                )
 
 
 
@@ -36,43 +39,46 @@ data ExpensesCmd
 
 
 csvMode :: ExpensesCmd
-csvMode = CSV
-  { src = def &= typ "EXPENSES.TXT" &= argPos 1
-  , out = def &= typ "OUT.CSV" &= argPos 2
-  } &= help "Output to CSV"
+csvMode =
+  CSV { src = def &= typ "EXPENSES.TXT" &= argPos 1
+      , out = def &= typ "OUT.CSV" &= argPos 2
+      }
+    &= help "Output to CSV"
 
 
 
 -- I'm not sure why argPos is 0 here, when it's 1 2 above;
 -- but if I change the csvMode then the ledgerMode breaks.
 checkMode :: ExpensesCmd
-checkMode = Check
-  { src = def &= typ "EXPENSES.TXT" &= argPos 0
-  } &= help "Check expenses file"
+checkMode = Check { src = def &= typ "EXPENSES.TXT" &= argPos 0 }
+  &= help "Check expenses file"
 
 
 
 queryMode :: ExpensesCmd
-queryMode = Query
-  { attribute = def &= typ "earliest|latest" &= argPos 1
-  , src = def &= typ "EXPENSES.TXT" &= argPos 2
-  } &= help "Query attributes of expenses file"
+queryMode =
+  Query { attribute = def &= typ "earliest|latest" &= argPos 1
+        , src       = def &= typ "EXPENSES.TXT" &= argPos 2
+        }
+    &= help "Query attributes of expenses file"
 
 
 
 ledgerMode :: ExpensesCmd
-ledgerMode = Ledger
-  { src = def &= argPos 0 &= typ "EXPENSES.TXT"
-  , out = def &= argPos 1 &= typ "JOURNAL.LEDGER"
-  , no_accounts = def &= typ "Fill in accounts "
-  , journal = def &= typ "ledger.dat"
-  } &= help "Output to Ledger format"
+ledgerMode =
+  Ledger { src         = def &= argPos 0 &= typ "EXPENSES.TXT"
+         , out         = def &= argPos 1 &= typ "JOURNAL.LEDGER"
+         , no_accounts = def &= typ "Fill in accounts "
+         , journal     = def &= typ "ledger.dat"
+         }
+    &= help "Output to Ledger format"
 
 
 
 mode :: Mode (CmdArgs ExpensesCmd)
 mode =
-  cmdArgsMode $ modes [checkMode, csvMode, queryMode, ledgerMode]
+  cmdArgsMode
+    $  modes [checkMode, csvMode, queryMode, ledgerMode]
     &= help "Utils for expenses file format"
     &= program "expenses-utils"
     &= summary "Expenses Utils v0.2.1"


### PR DESCRIPTION
Formatting `src/` haskell files using brittany.

There's a small percentage of code which I think was clearer without the auto-formatting, but I can lose that for the *consistency* of the auto-formatter.

Not formatting `test/` dir since I don't think it works well with how I want to read Hspec.